### PR TITLE
Fix `CollectionComparer<>`

### DIFF
--- a/Source/NCompare.UnitTests/Samples/CollectionComparer`1.cs
+++ b/Source/NCompare.UnitTests/Samples/CollectionComparer`1.cs
@@ -36,7 +36,7 @@ internal sealed class CollectionComparer<T> : IEqualityComparer<IReadOnlyCollect
         hashCode.Add(item, EqualityComparer);
       }//for
     }//if
-    return hashCode.GetHashCode();
+    return hashCode.ToHashCode();
   }
 
   public int Compare(IReadOnlyCollection<T>? x, IReadOnlyCollection<T>? y) {


### PR DESCRIPTION
Use `hashCode.ToHashCode()` instead of `hashCode.GetHashCode()`.

Fixing #5