### PR TITLE
Update referenced packages to newer versions

### DIFF
--- a/Source/NCompare.Benchmarks/NCompare.Benchmarks.csproj
+++ b/Source/NCompare.Benchmarks/NCompare.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0; net461</TargetFrameworks>
+    <TargetFrameworks>net8.0; net462</TargetFrameworks>
     <LangVersion>Preview</LangVersion>
     <Nullable>Enable</Nullable>
     <WarningLevel>9999</WarningLevel>

--- a/Source/NCompare.Benchmarks/NCompare.Benchmarks.csproj
+++ b/Source/NCompare.Benchmarks/NCompare.Benchmarks.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.11" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageReference Include="Nito.Comparers" Version="6.2.2" />
   </ItemGroup>
 

--- a/Source/NCompare.UnitTests/AssemblyAttributes.cs
+++ b/Source/NCompare.UnitTests/AssemblyAttributes.cs
@@ -1,3 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 
 [assembly: ExcludeFromCodeCoverage(Justification = "UnitTests assembly does not need code coverage.")]
+[assembly: Parallelize]

--- a/Source/NCompare.UnitTests/General.Interception.cs
+++ b/Source/NCompare.UnitTests/General.Interception.cs
@@ -1,7 +1,5 @@
 ﻿using System.Diagnostics;
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-
 namespace NCompare.UnitTests;
 
 partial class General

--- a/Source/NCompare.UnitTests/General.Nested.cs
+++ b/Source/NCompare.UnitTests/General.Nested.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-namespace NCompare.UnitTests;
+﻿namespace NCompare.UnitTests;
 
 using static TestCompare;
 

--- a/Source/NCompare.UnitTests/General.Overloads.cs
+++ b/Source/NCompare.UnitTests/General.Overloads.cs
@@ -1,7 +1,5 @@
 ﻿using System.Diagnostics;
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-
 namespace NCompare.UnitTests;
 
 partial class General

--- a/Source/NCompare.UnitTests/General.cs
+++ b/Source/NCompare.UnitTests/General.cs
@@ -1,7 +1,5 @@
 // Ignore Spelling: Nullable
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-
 namespace NCompare.UnitTests;
 
 using static TestCompare;
@@ -10,7 +8,7 @@ using static TestCompare;
 public sealed partial class General
 {
   private static void AssertException<TException>(Action action, string message) where TException : Exception {
-    var ex = Assert.ThrowsException<TException>(action);
+    var ex = Assert.Throws<TException>(action);
     Assert.IsNotNull(ex);
     Assert.AreEqual(expected: message, ex.Message);
   }
@@ -111,8 +109,8 @@ public sealed partial class General
     Assert.AreEqual(expected: 0, compare, $"{x.Number} == {y.Number}");
 
     var z = new TestValue(2);
-    Assert.IsTrue(equality.Compare(x, z) < 0, $"{x.Number} < {z.Number}");
-    Assert.IsTrue(equality.Compare(z, y) > 0, $"{z.Number} < {y.Number}");
+    Assert.IsLessThan(0, equality.Compare(x, z), $"{x.Number} < {z.Number}");
+    Assert.IsGreaterThan(0, equality.Compare(z, y), $"{z.Number} < {y.Number}");
   }
 
   [TestMethod]

--- a/Source/NCompare.UnitTests/NCompare.UnitTests.csproj
+++ b/Source/NCompare.UnitTests/NCompare.UnitTests.csproj
@@ -14,8 +14,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/NCompare.UnitTests/NCompare.UnitTests.csproj
+++ b/Source/NCompare.UnitTests/NCompare.UnitTests.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
   </ItemGroup>

--- a/Source/NCompare.UnitTests/Recursion.cs
+++ b/Source/NCompare.UnitTests/Recursion.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-namespace NCompare.UnitTests;
+﻿namespace NCompare.UnitTests;
 
 using static TestCompare;
 

--- a/Source/NCompare.UnitTests/Samples/PersonAndAddress.cs
+++ b/Source/NCompare.UnitTests/Samples/PersonAndAddress.cs
@@ -1,8 +1,6 @@
 ﻿using System.Numerics;
 using System.Runtime.CompilerServices;
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-
 namespace NCompare.UnitTests.Samples;
 
 using static TestCompare;

--- a/Source/NCompare.UnitTests/Samples/PersonAndAddress.cs
+++ b/Source/NCompare.UnitTests/Samples/PersonAndAddress.cs
@@ -34,7 +34,7 @@ public sealed class PersonAndAddress
     Assert.AreEqual(expected: 0, compare12);
 
     var compare23 = PersonComparer.Compare(person2, person3);
-    Assert.IsTrue(compare23 < 0);
+    Assert.IsLessThan(0, compare23);
   }
 
   [TestMethod]

--- a/Source/NCompare.UnitTests/TestCompare.cs
+++ b/Source/NCompare.UnitTests/TestCompare.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-namespace NCompare.UnitTests;
+﻿namespace NCompare.UnitTests;
 
 internal static class TestCompare
 {


### PR DESCRIPTION
* Update MSTest to 4.0.2
  * Remove namespace from UnitTests
* Update Microsoft.NET.Test.Sdk to 18.0.1
* Update BenchmarkDotNet to 0.15.8
  * Migrate Benchmarks to net462 from net461
     .NET Framework 4.6.1 is out of support since April 26, 2022








